### PR TITLE
adding site feedback link, experimenting with email templates

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,11 +7,11 @@
   <div class="usa-footer-primary-section">
     <div class="grid-container">
       <div class="usa-footer-logo grid-row grid-gap-2">
-        <div class="grid-col-8">
+        <div class="grid-col-12 tablet:grid-col-9">
           <p class="usa-footer--text">PRA.gov’s content is maintained by <a href="https://www.whitehouse.gov/omb/information-regulatory-affairs/">The Office of Information and Regulatory Affairs (OIRA)</a> and PRA officers across federal government.  This site is a product of <a href="https://10x.gsa.gov/">10x</a> and is supported by <a href="https://digital.gov/">Digital.gov.</a></p>
           <p class="usa-footer--text">Help us improve this site <a href="https://github.com/GSA/pra.gov">on GitHub.</a></p>
         </div>
-        <div class="grid-col-4 usa-footer--feedback">
+        <div class="grid-col-12 tablet:grid-col-3 usa-footer--feedback">
           <p class="usa-footer--text">
             <a href="mailto:PRA@omb.eop.gov?subject=PRA.gov:%20Site%20Feedback&body=Please%20fill%20out%20the%20information%20below%0A%0A%0AWhat%20were%20you%20trying%20to%20do?%0A%0A%0AGeneral%20Comments">
                Send us site feedback.</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,9 +7,15 @@
   <div class="usa-footer-primary-section">
     <div class="grid-container">
       <div class="usa-footer-logo grid-row grid-gap-2">
-        <div class="grid-col-auto">
+        <div class="grid-col-8">
           <p class="usa-footer--text">PRA.gov’s content is maintained by <a href="https://www.whitehouse.gov/omb/information-regulatory-affairs/">The Office of Information and Regulatory Affairs (OIRA)</a> and PRA officers across federal government.  This site is a product of <a href="https://10x.gsa.gov/">10x</a> and is supported by <a href="https://digital.gov/">Digital.gov.</a></p>
           <p class="usa-footer--text">Help us improve this site <a href="https://github.com/GSA/pra.gov">on GitHub.</a></p>
+        </div>
+        <div class="grid-col-4 usa-footer--feedback">
+          <p class="usa-footer--text">
+            <a href="mailto:PRA@omb.eop.gov?subject=PRA.gov:%20Site%20Feedback&body=Please%20fill%20out%20the%20information%20below%0A%0A%0AWhat%20were%20you%20trying%20to%20do?%0A%0A%0AGeneral%20Comments">
+               Send us site feedback.</a>
+            </p>
         </div>
       </div>
     </div>

--- a/_scss/components/_footer.scss
+++ b/_scss/components/_footer.scss
@@ -15,5 +15,5 @@
 }
 
 .usa-footer--feedback {
-  text-align: right;
+  padding: 1rem 0;
 }

--- a/_scss/components/_footer.scss
+++ b/_scss/components/_footer.scss
@@ -13,3 +13,7 @@
 .usa-footer-logo-img.digital-gov{
   max-width: 10rem;
 }
+
+.usa-footer--feedback {
+  text-align: right;
+}


### PR DESCRIPTION
Adding a "Send us site feedback" link in the footer. This also experiments with populating an email template. Currently, this link creates an email that looks like this:

<img width="837" alt="Screen Shot 2019-04-02 at 3 39 36 PM" src="https://user-images.githubusercontent.com/2374206/55431447-91a04f80-555e-11e9-969b-f00ddf6cf7a0.png">

A few notes:
* I'm not sure what our difference should be between "Improve this site via git" and "Give us site feedback". They feel similar and it feels strange having them in the same area.
* The mobile interaction here needs work, was having trouble getting the mobile helper classes to call properly. 