### PR TITLE
Moving supporting statement content

### DIFF
--- a/_pages/clearance-process/index.md
+++ b/_pages/clearance-process/index.md
@@ -62,12 +62,6 @@ With your agency, you’ll submit an Information Clearance Request (ICR) for rev
 - Guides or instructions for interviewers,
 - Explanatory material to be given to prospective respondents, and prepared material to be given to members of the public who do not respond.
 
-## What makes a good supporting statement?
-
-A clear supporting statement will help OMB and the public better understand your collection and reduce the need for questions aimed at simply trying to understand the overall collection, Be sure to give information about the authority your agency has to collect the type of information in your proposal.
-
-The PRA approval process helps ensure the collection meets the standards of the PRA such as minimizing burden on the public and also helps to ensure it is being conducted in a way that uses appropriate methods and analysis.
-
 ## OMB review timeline and process
 
 OMB typically reviews ICR packages within sixty days, from the submission date or the publication of the 30-day Federal Register notice (whichever is later), but can take longer in some circumstances.

--- a/_pages/clearance-process/supporting-statement.md
+++ b/_pages/clearance-process/supporting-statement.md
@@ -4,6 +4,10 @@ title: Supporting Statements
 
 The Supporting Statement is a set of required questions that help provide a clear rationale for the why, what, how, who of the information collection. All Supporting Statements have a Part A, 18 questions which show compliance with the PRA and other associated laws. Collections that require statistical methods, like surveys or program evaluations, have additional requirements, called Part B. 
 
+## What makes a good supporting statement?
+
+A clear supporting statement will help OMB and the public better understand your collection and reduce the need for questions aimed at simply trying to understand the overall collection, Be sure to give information about the authority your agency has to collect the type of information in your proposal.
+
 A few of the criteria covered in the Supporting Statement include: 
 
 *	Agency purpose 


### PR DESCRIPTION
Now that we have a whole page on Supporting Statements, this content feels like it makes more sense on that page.